### PR TITLE
Add hotel-research environment and NODE_ENV-based env file resolution

### DIFF
--- a/.env.hotel-research
+++ b/.env.hotel-research
@@ -1,0 +1,41 @@
+# Hotel research environment
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=password
+DB_NAME=hotel_research_backend
+
+# Redis Configuration
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=1
+
+# RabbitMQ Configuration
+RABBITMQ_URL=amqp://localhost:5672
+
+# JWT Configuration
+JWT_SECRET=hotel-research-super-secret-key
+
+# Stripe Configuration
+STRIPE_SECRET_KEY=sk_test_hotel_research_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_hotel_research_webhook_secret
+
+# Resend Configuration
+RESEND_API_KEY=re_hotel_research_api_key
+RESEND_FROM_EMAIL=hotel-research@yourdomain.com
+
+# Elasticsearch Configuration
+ELASTICSEARCH_NODE=http://localhost:9200
+ELASTICSEARCH_USERNAME=
+ELASTICSEARCH_PASSWORD=
+ELASTICSEARCH_INDEX_PREFIX=hotel_research_
+
+# MongoDB Configuration
+MONGODB_URI=mongodb://localhost:27017/hotel_research_chat
+
+# Application Configuration
+NODE_ENV=hotel-research
+PORT=3100
+CORS_ORIGIN=http://localhost:3100
+FRONTEND_URL=http://localhost:3100

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ A robust, production-ready backend system built with NestJS, featuring PostgreSQ
    
    Update the `.env` file with your configuration.
 
+   **Hotel research environment (alternative)**
+   ```bash
+   cp .env.hotel-research .env
+   ```
+
+   Or run with:
+   ```bash
+   NODE_ENV=hotel-research npm run start:dev
+   ```
+
 ## 🐳 Docker Development
 
 1. **Start services with Docker Compose**

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,11 +24,18 @@ import { redisConfig } from './config/redis.config';
 import { elasticsearchConfig } from './config/elasticsearch.config';
 import { mongodbConfig } from './config/mongodb.config';
 
+const nodeEnv = process.env.NODE_ENV;
+const envFilePaths = [
+  nodeEnv ? `.env.${nodeEnv}` : undefined,
+  '.env.local',
+  '.env',
+].filter(Boolean) as string[];
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: ['.env.local', '.env'],
+      envFilePath: envFilePaths,
       load: [databaseConfig, redisConfig, elasticsearchConfig, mongodbConfig],
     }),
     


### PR DESCRIPTION
### Motivation
- Provide a dedicated environment configuration for a separate "Hotel research" setup and enable automatic loading of environment files based on `NODE_ENV` so alternate envs can be used without changing code.

### Description
- Add NODE_ENV-aware env file resolution in `src/app.module.ts` so `ConfigModule.forRoot` will load ` .env.<NODE_ENV>` (if present) before `.env.local` and `.env` by building `envFilePaths` dynamically.
- Add a new environment template file ` .env.hotel-research` containing DB, Redis, RabbitMQ, JWT, Stripe, Resend, Elasticsearch, MongoDB, and application settings for the Hotel research environment.
- Update `README.md` to document how to use the Hotel research environment via `cp .env.hotel-research .env` or `NODE_ENV=hotel-research npm run start:dev`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5e1fc538832a961ab9d19e59c30c)